### PR TITLE
Cleanup of SVG icon - no need to define the linearGradient twice.

### DIFF
--- a/src/Panel.php
+++ b/src/Panel.php
@@ -73,18 +73,14 @@ class Panel implements IBarPanel
 						}'
 				. '</style>'
 				. '<span id="performance-panel" title="Performance Tracy Panel">'
-					. '<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+					. '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 		 					viewBox="0 0 33.1 11.7" enable-background="new 0 0 33.1 11.7" xml:space="preserve">
 							<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="5.8319" y1="0.5" x2="5.8319" y2="11.1638">
 								<stop  offset="0" style="stop-color:#FFFFFF"/>
 								<stop  offset="1" style="stop-color:#F7A69E"/>
 							</linearGradient>
 							<rect x="0.5" y="0.5" fill="url(#SVGID_1_)" stroke="#773B37" width="10.7" height="10.7"/>
-							<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="27.3105" y1="0.5" x2="27.3105" y2="11.1638">
-								<stop  offset="0" style="stop-color:#FFFFFF"/>
-								<stop  offset="1" style="stop-color:#F7A69E"/>
-							</linearGradient>
-							<rect x="22" y="0.5" fill="url(#SVGID_2_)" stroke="#773B37" width="10.7" height="10.7"/>
+							<rect x="22" y="0.5" fill="url(#SVGID_1_)" stroke="#773B37" width="10.7" height="10.7"/>
 							<polygon fill="#9ADAEA" stroke="#28A0DA" points="16.5,8.1 14,8.1 14,10.5 9,5.9 14,1.2 14,3.6 16.5,3.6 "/>
 							<polygon fill="#9ADAEA" stroke="#28A0DA" points="16.5,8.1 19,8.1 19,10.5 24.1,5.7 19.1,1.2 19.1,3.6 16.5,3.6 "/>'
 					. '</svg>'


### PR DESCRIPTION
Could have gone even further by making the arrow a `<symbol>` and then
`<use>`’d it with a transform to reflect it, but not worth it. I think
this is a nice simplification though.
